### PR TITLE
Truncate descriptions of podcasts and episodes

### DIFF
--- a/app/views/podcasts/index.html.haml
+++ b/app/views/podcasts/index.html.haml
@@ -19,4 +19,4 @@
             %h4.card-title
               = link_to podcast.title, podcast
             = link_to podcast do
-              %p.card-text= podcast.description
+              %p.card-text= podcast.description.truncate_words 25

--- a/app/views/podcasts/show.html.haml
+++ b/app/views/podcasts/show.html.haml
@@ -48,7 +48,7 @@
           %h5.media-heading
             =link_to episode.title, episode
           .media-text
-            = episode.summary
+            = episode.summary.truncate_words 20
           .date-inline
             = episode.published_at
         .media-right


### PR DESCRIPTION
  So that descriptions fit in the containers
- truncate the desc of podcasts in podcast lists
- truncate the desc of episodes in episode lists
