### PR TITLE
Fix utf8 emojis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,6 @@ group :development do
   gem 'spring'
 end
 
-group :production do 
-  # Support for PostgreSQL
-  gem "pg"
-end
+# Support for PostgreSQL
+gem "pg"
+

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,12 +10,11 @@
 #   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
 #
 default: &default
-  adapter: mysql2
-  encoding: utf8
+  adapter: postgresql
+  encoding: unicode
   pool: 5
-  username: root
+  username: pguser
   password: 1q2w3e4r
-  socket: /var/run/mysqld/mysqld.sock
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -54,3 +54,4 @@ production:
 
 cucumber:
   <<: *test
+

--- a/db/seeds/all.rb
+++ b/db/seeds/all.rb
@@ -3,6 +3,6 @@ Podcast.create([
   { rss_link: 'http://www.howstuffworks.com/podcasts/stuff-you-should-know.rss' }, 
   { rss_link: 'http://feeds.feedburner.com/freakonomicsradio' },
   { rss_link: 'http://podster.fm/rss.xml?pid=313' },
-  #{ rss_link: 'http://atp.fm/episodes?format=rss' },
+  { rss_link: 'http://atp.fm/episodes?format=rss' },
   { rss_link: 'http://golangshow.com/index.xml' }
 ])


### PR DESCRIPTION
Switch the development and test environments to using postgresql because:
- mysql does not support 4 byte utf8 symbols out of the box
- production environment on heroku uses postgres, so might as well make them more alike
